### PR TITLE
Add buster versions of PHP 7.3

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,15 @@ services:
         VERSION: 7.3
         BASEOS: stretch
 
+  php73-fpm-buster-base:
+    image: my127/magento2:7.3-fpm-buster
+    build:
+      context: ./
+      dockerfile: base.Dockerfile
+      args:
+        VERSION: 7.3
+        BASEOS: buster
+
   php74-fpm-buster-base:
     image: my127/magento2:7.4-fpm-buster
     build:
@@ -67,6 +76,15 @@ services:
       args:
         VERSION: 7.3
         BASEOS: stretch
+
+  php73-fpm-buster-console:
+    image: my127/magento2:7.3-fpm-stretch-console
+    build:
+      context: ./
+      dockerfile: console.Dockerfile
+      args:
+        VERSION: 7.3
+        BASEOS: buster
 
   php74-fpm-buster-console:
     image: my127/magento2:7.4-fpm-buster-console


### PR DESCRIPTION
The redis-cli doesn't work on stretch